### PR TITLE
specify retry topic per topic

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,7 +56,7 @@ From maven central:
 
     // build a consumer-pool 
     ReliableKafkaConsumerPool<String,String> pool = new ReliablePoolBuilder<>(eventClientFactory)
-                .topics(List.of(TOPIC, TOPIC2)) // list of topics to subscribe to
+                .topics(List.of(TOPIC, TOPIC2)) // list of topics to subscribe to, will generate retry topics
                 .poolCount(5) // optional: number of threads consuming from kafka 
                 .processingFunction(record -> process(record)) // required : a function that processes records
                 .retryPeriodMillis(24 * 60 * 60 * 1000) // optional: how long a message should be retried before given up on
@@ -69,6 +69,21 @@ From maven central:
     // optional: check if all consumer-threads are alive, recommended to check these every minute or so
     pool.monitor.monitor()
 
+## Explicitly set retry topics  
+
+    // build a consumer-pool 
+    ReliableKafkaConsumerPool<String,String> pool = new ReliablePoolBuilder<>(eventClientFactory)
+                .topicsRetryTopics(Collections.singletonMap(TOPIC, RETRY_TOPIC)) //explicitly set retry topic.
+                .poolCount(5) // optional: number of threads consuming from kafka 
+                .processingFunction(record -> process(record)) // required : a function that processes records
+                .retryPeriodMillis(24 * 60 * 60 * 1000) // optional: how long a message should be retried before given up on
+                .retryThrottleMillis(5_000) // optional: specify how fast a message should be retried
+                .build();
+                
+    pool.monitor.start(); // start the pool
+    
+    // optional: check if all consumer-threads are alive, recommended to check these every minute or so
+    pool.monitor.monitor()
 
 # Detailed description 
 

--- a/src/test/java/no/finn/retriableconsumer/PoolBuilderTest.java
+++ b/src/test/java/no/finn/retriableconsumer/PoolBuilderTest.java
@@ -2,10 +2,25 @@ package no.finn.retriableconsumer;
 
 import org.junit.Test;
 
+import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
+
 public class PoolBuilderTest {
 
     @Test(expected = IllegalStateException.class)
-    public void test_some(){
+    public void test_some() {
         new ReliablePoolBuilder<>(null).build();
     }
+
+    @Test
+    public void topic_name() {
+        String retryTopic = ReliablePoolBuilder.retryTopicName("sometopic", "mygroup");
+        assertThat(retryTopic).isEqualToIgnoringCase("retry-mygroup-sometopic");
+    }
+
+    @Test
+    public void dont_prefix_if_already_prefixed() {
+        String retryTopic = ReliablePoolBuilder.retryTopicName("retry-sometopic", "mygroup");
+        assertThat(retryTopic).isEqualToIgnoringCase("retry-sometopic");
+    }
+
 }

--- a/src/test/java/no/finn/retriableconsumer/RestartableKafkaConsumerTest.java
+++ b/src/test/java/no/finn/retriableconsumer/RestartableKafkaConsumerTest.java
@@ -3,6 +3,7 @@ package no.finn.retriableconsumer;
 import java.util.Arrays;
 import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.function.Function;
 
@@ -134,7 +135,11 @@ public class RestartableKafkaConsumerTest {
 
 
         Producer<String, String> mockProducer = mock(Producer.class);
-        RetryHandler<String, String> failer = new RetryHandler<>(() -> mockProducer, 100, "testgroupid");
+        Map<String, String> topicsRetryTopic = new HashMap<String, String>() {{
+            put("topic", "retry-topic");
+            put("topic1", "retry-topic1");
+        }};
+        RetryHandler<String, String> failer = new RetryHandler<>(() -> mockProducer, 100, topicsRetryTopic);
 
 
         RestartableKafkaConsumer<String, String> consumer =

--- a/src/test/java/no/finn/retriableconsumer/RestartableRetryProducerTest.java
+++ b/src/test/java/no/finn/retriableconsumer/RestartableRetryProducerTest.java
@@ -9,7 +9,9 @@ import org.junit.Test;
 import org.mockito.ArgumentCaptor;
 
 import java.util.Arrays;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 import java.util.concurrent.CompletableFuture;
 
 import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
@@ -20,7 +22,7 @@ import static org.mockito.Mockito.when;
 
 public class RestartableRetryProducerTest {
 
-    @Test
+/*    @Test
     public void topic_name() {
 
         String retryTopic = RetryHandler.retryTopicName("sometopic", "mygroup");
@@ -34,12 +36,17 @@ public class RestartableRetryProducerTest {
         String retryTopic = RetryHandler.retryTopicName("retry-sometopic", "mygroup");
 
         assertThat(retryTopic).isEqualToIgnoringCase("retry-sometopic");
-    }
+    }*/
 
     @Test
     public void create_producer_record_with_correct_headers_for_first_time_failing_Record() {
+        Map<String, String> topicsRetryTopics = new HashMap<String, String>() {{
+            put("topic", "retry-topic");
+        }};
 
-        RetryHandler<String, String> producer = new RetryHandler<>( ()->null, 500, "");
+        RetryHandler<String, String> producer = new RetryHandler<>( ()->null, 500, topicsRetryTopics);
+
+
 
         ConsumerRecord<String, String> oldRecord = new ConsumerRecord<>("topic", 0, 0, "key", "value");
         ProducerRecord retryRecord = producer.createRetryRecord(oldRecord, "retry-topic", 1000);
@@ -56,8 +63,11 @@ public class RestartableRetryProducerTest {
 
     @Test
     public void conserve_timestamp_header_increse_counter_header() {
+        Map<String, String> topicsRetryTopics = new HashMap<String, String>() {{
+            put("topic", "retry-topic");
+        }};
 
-        RetryHandler<String, String> producer = new RetryHandler<>( ()->null, 500, "");
+        RetryHandler<String, String> producer = new RetryHandler<>( ()->null, 500, topicsRetryTopics);
 
         ConsumerRecord<String, String> oldRecord = new ConsumerRecord<>("topic", 0, 0, "key", "value");
         oldRecord.headers().add(new RecordHeader(RetryHandler.HEADER_KEY_REPROCESS_COUNTER, "41".getBytes()));
@@ -79,8 +89,11 @@ public class RestartableRetryProducerTest {
 
     @Test
     public void parse_produced_counter_headers() {
+        Map<String, String> topicsRetryTopics = new HashMap<String, String>() {{
+            put("topic", "retry-topic");
+        }};
 
-        RetryHandler<String, String> producer = new RetryHandler<>( ()->null, 500, "");
+        RetryHandler<String, String> producer = new RetryHandler<>( ()->null, 500, topicsRetryTopics);
 
         ConsumerRecord<String, String> oldRecord = new ConsumerRecord<>("topic", 0, 0, "key", "value");
         ProducerRecord retryRecord = producer.createRetryRecord(oldRecord, "retry-topic", 1000);
@@ -97,8 +110,11 @@ public class RestartableRetryProducerTest {
 
     @Test
     public void parse_produced_timestamp_header() {
+        Map<String, String> topicsRetryTopics = new HashMap<String, String>() {{
+            put("topic", "retry-topic");
+        }};
 
-        RetryHandler<String, String> producer = new RetryHandler<>( ()->null, 500, "");
+        RetryHandler<String, String> producer = new RetryHandler<>( ()->null, 500, topicsRetryTopics);
 
         ConsumerRecord<String, String> oldRecord = new ConsumerRecord<>("topic", 0, 0, "key", "value");
         ProducerRecord retryRecord = producer.createRetryRecord(oldRecord, "retry-topic", 1000);
@@ -125,7 +141,11 @@ public class RestartableRetryProducerTest {
 
         ConsumerRecord<String, String> failedRecord = new ConsumerRecord<>("foo", 0, 0, "bar", "baz");
 
-        RetryHandler<String, String> retryProducer =new RetryHandler<>(()->kafkaProducerMock,100, "groupid");
+        Map<String, String> topicsRetryTopics = new HashMap<String, String>() {{
+            put("foo", "retry-groupid-foo");
+        }};
+
+        RetryHandler<String, String> retryProducer =new RetryHandler<>(()->kafkaProducerMock,100, topicsRetryTopics);
 
         retryProducer.accept(failedRecord);
 

--- a/src/test/kotlin/KafkaIntegrationTest.kt
+++ b/src/test/kotlin/KafkaIntegrationTest.kt
@@ -41,7 +41,7 @@ class KafkaIntegrationTest {
         }
         val pollFunction = Function<Consumer<String, String>, ConsumerRecords<String, String>> { it.poll(1) }
 
-        val pool = ReliableKafkaConsumerPool(3, factory, listOf("foo"), process, pollFunction, 10, 10_000)
+        val pool = ReliableKafkaConsumerPool(3, factory, mapOf("foo" to "retry-foo"), process, pollFunction, 10, 10_000)
 
         pool.monitor.start()
 
@@ -80,7 +80,7 @@ class KafkaIntegrationTest {
         }
         val poll = Function<Consumer<String, String>, ConsumerRecords<String, String>> { it.poll(1) }
 
-        val pool = ReliableKafkaConsumerPool(3, factory, listOf("foo"), process, poll, 10, 10_000_000)
+        val pool = ReliableKafkaConsumerPool(3, factory, mapOf("foo" to "retry-foo"), process, poll, 10, 10_000_000)
 
         pool.monitor.start()
 

--- a/src/test/kotlin/no/finn/retriableconsumer/ReliableKafkaConsumerPoolTest.kt
+++ b/src/test/kotlin/no/finn/retriableconsumer/ReliableKafkaConsumerPoolTest.kt
@@ -23,7 +23,7 @@ class ReliableKafkaConsumerPoolTest {
         val processingFunction = Function<ConsumerRecord<String, String>, Boolean> { TODO("not in use") }
         val pollFunction = Function<Consumer<String, String>, ConsumerRecords<String, String>> { TODO("not in use") }
 
-        val pool = ReliableKafkaConsumerPool(1, factory, Collections.singletonList("topic"), processingFunction, pollFunction,100, 100_000)
+        val pool = ReliableKafkaConsumerPool(1, factory, mapOf("topic" to "retry-topic"), processingFunction, pollFunction,100, 100_000)
 
         assertEquals(2, pool.size())
     }


### PR DESCRIPTION
need to support creating topics upfront on systems configured without auto-creation of topics - groupid may be too dynamic