### PR TITLE
Assure retry message sent before proceeding

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -34,6 +34,12 @@
             <organization>Kodemaker</organization>
             <organizationUrl>https://kodemaker.no</organizationUrl>
         </developer>
+        <developer>
+            <email>kenneth.tiller@outlook.com</email>
+            <name>Kenneth Tiller</name>
+            <organization>FINN.no</organization>
+            <organizationUrl>https://finn.no</organizationUrl>
+        </developer>
     </developers>
 
     <scm>


### PR DESCRIPTION
In current implementation we can risk that retry message is not actually produced and committed to kafka queue before we commit record consumption.

Risk is low, since retry handler is doing a Thread.sleep after queueing, but to be totally safe we should rather do blocking call until confirmed RecordMetaData is returned in the Future. 